### PR TITLE
Adds swagger ui wrapper to auth section

### DIFF
--- a/themes/cmsgov-api-doc/assets/openapi.js
+++ b/themes/cmsgov-api-doc/assets/openapi.js
@@ -29,7 +29,7 @@ class AuthsLayout extends React.Component {
             return React.createElement(Auths, auth_props);
         })
 
-        return React.createElement("div", { className: "auth-wrapper" }, auths);
+        return React.createElement("div", { className: "auth-wrapper swagger-ui" }, auths);
     }
 }
 


### PR DESCRIPTION
Adds the swagger UI class to the openapi.js for a wrapper. I also included some custom CSS to target the swagger UI and make things a little bit cleaner on that page.